### PR TITLE
Extending the capability of PPTrajectory append 

### DIFF
--- a/drake/systems/trajectories/PPTrajectory.m
+++ b/drake/systems/trajectories/PPTrajectory.m
@@ -601,9 +601,9 @@ classdef (InferiorClasses = {?ConstantTrajectory, ?Point}) PPTrajectory < Trajec
       secondStart = trajAtEnd.pp.breaks(1);
       
       if (firstEnd ~= secondStart)
-        error(strcat('Cannot append trajectories that do not start/end at the same time.', ...
+        warning(strcat('Cannot append trajectories that do not start/end at the same time.', ...
           'First trajectory ends at t = ',num2str(firstEnd), ...
-          ' but the second trajectory starts at t = ', num2str(secondStart)));
+          ' but the second trajectory starts at t = ', num2str(secondStart),'Reverting to zamzami implementation'));
       end
       
             
@@ -635,6 +635,30 @@ classdef (InferiorClasses = {?ConstantTrajectory, ?Point}) PPTrajectory < Trajec
         k=obj.pp.order;
         trajAtEnd.pp = mkpp(trajAtEnd.pp.breaks,reshape(coefs,[d,l,k]),d);
       end
+      
+      if(firstEnd ~= secondStart)
+        warning('Appending trajectories with different intervals.')
+          
+        newtraj = obj;
+      
+      newtraj.pp.dim = obj.pp.dim;
+      newtraj.pp.order = obj.pp.order;
+      
+      newtraj.pp.pieces = obj.pp.pieces + trajAtEnd.pp.pieces;
+      
+      
+      newbreaks=trajAtEnd.pp.breaks+obj.pp.breaks(end);
+      
+      newtraj.pp.breaks = [obj.pp.breaks newbreaks(2:end)];
+      newtraj.pp.coefs = [obj.pp.coefs; trajAtEnd.pp.coefs];  
+      
+      newtraj = setOutputFrame(PPTrajectory(newtraj.pp),getOutputFrame(obj));
+      
+      newtraj.dim = obj.dim;
+      
+      newtraj.tspan = [newtraj.pp.breaks(1) newtraj.pp.breaks(end)];   
+          
+      else     
         
       newtraj = obj;
       
@@ -654,6 +678,7 @@ classdef (InferiorClasses = {?ConstantTrajectory, ?Point}) PPTrajectory < Trajec
       newtraj.dim = obj.dim;
       
       newtraj.tspan = [min(obj.pp.breaks) max(trajAtEnd.pp.breaks)];
+      end 
     end % append
     
     % should getParameters and setParameters include the breaks? or just


### PR DESCRIPTION
Extending `append` method to operate on `PPTrajectory` with overlapping
timespan. This is useful in case of appending trajectories found using
RRT which typically starts with time at zero and ends at a variable time determined probabilistically.